### PR TITLE
Fix #219. Tested it. Now lets look at One.

### DIFF
--- a/provision/box_compute.go
+++ b/provision/box_compute.go
@@ -17,6 +17,7 @@ package provision
 
 import (
 	"regexp"
+	"strconv"
 	"strings"
 
 	"github.com/pivotal-golang/bytefmt"
@@ -35,7 +36,7 @@ func (bc *BoxCompute) trimCore() string {
 }
 
 func (bc *BoxCompute) numCpushare() uint64 {
-	if cs, err := bytefmt.ToMegabytes(bc.trimCore()); err != nil {
+	if cs, err := strconv.ParseUint(bc.trimCore(), 10, 64); err != nil {
 		return 0
 	} else {
 		return cs
@@ -83,8 +84,8 @@ func (bc *BoxCompute) numHDD() uint64 {
 
 func (bc *BoxCompute) String() string {
 	return "(" + strings.Join([]string{
-		CPU + ":" + string(bc.numCpushare()),
-		RAM + ":" + string(bc.numMemory()),
-		HDD + ":" + string(bc.numHDD())},
+		CPU + ":" + strconv.FormatInt(int64(bc.numCpushare()), 10),
+		RAM + ":" + strconv.FormatInt(int64(bc.numMemory()), 10),
+		HDD + ":" + strconv.FormatInt(int64(bc.numHDD()), 10)},
 		",") + " )"
 }

--- a/provision/one/machine/machine.go
+++ b/provision/one/machine/machine.go
@@ -4,6 +4,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"io"
+	"strconv"
 	"strings"
 	"time"
 
@@ -48,9 +49,9 @@ func (m *Machine) Create(args *CreateArgs) error {
 	opts := compute.VirtualMachine{
 		Name:   m.Name,
 		Image:  m.Image,
-		Cpu:    string(args.Box.GetCpushare()), //ugly, compute has the info.
-		Memory: string(args.Box.GetMemory()),
-		HDD:    string(args.Box.GetHDD()),
+		Cpu:    strconv.FormatInt(int64(args.Box.GetCpushare()), 10), //ugly, compute has the info.
+		Memory: strconv.FormatInt(int64(args.Box.GetMemory()), 10),
+		HDD:    strconv.FormatInt(int64(args.Box.GetHDD()), 10),
 		ContextMap: map[string]string{compute.ASSEMBLY_ID: args.Box.CartonId,
 			compute.ASSEMBLIES_ID: args.Box.CartonsId},
 	}


### PR DESCRIPTION
### Ok this is fixed.
@rajthilakmca  Please do a build of `vertice` and `nilavu` tomorrow. Lets ship the torpedo's out (all of them).

### Here is the XML.
```xml

<?xml version="1.0" encoding="UTF-8"?>
<Template>
   <CONTEXT>
      <NETWORK>YES</NETWORK>
      <FILES>/megam/init.sh</FILES>
      <SSH_PUBLIC_KEY />
      <SET_HOSTNAME>$NAME</SET_HOSTNAME>
      <NODE_NAME>$NAME</NODE_NAME>
      <ACCOUNTS_ID />
      <PLATFORM_ID />
      <ASSEMBLY_ID>ASM4945356555437998424</ASSEMBLY_ID>
      <ASSEMBLIES_ID>AMS5449234199553691032</ASSEMBLIES_ID>
   </CONTEXT>
   <CPU>1</CPU>
   <CPU_COST>5</CPU_COST>
   <DESCRIPTION>test trusty image</DESCRIPTION>
   <HYPERVISOR />
   <LOGO />
   <MEMORY>1024</MEMORY>
   <MEMORY_COST>10</MEMORY_COST>
   <SUNSTONE_CAPACITY_SELECT />
   <SUNSTONE_NETWORK_SELECT />
   <VCPU />
   <GRAPHICS>
      <LISTEN>0.0.0.0</LISTEN>
      <PORT />
      <TYPE>VNC</TYPE>
      <RANDOM_PASSWD />
   </GRAPHICS>
   <DISK>
      <DRIVER />
      <IMAGE>ubuntu_14.04</IMAGE>
      <IMAGE_UNAME>oneadmin</IMAGE_UNAME>
      <SIZE>24576</SIZE>
   </DISK>
   <FROM_APP />
   <FROM_APP_NAME />
   <NIC>
      <NETWORK>open-vs</NETWORK>
      <NETWORK_UNAME>oneadmin</NETWORK_UNAME>
   </NIC>
   <OS>
      <ARCH>x86_64</ARCH>
   </OS>
</Template>
```

### And the 3 vms i spun with `1 core, 1GB, 24GB SSD`
![megam_vertice](https://cloud.githubusercontent.com/assets/1402479/13642073/10ed783e-e641-11e5-92aa-e21082bce551.png)
